### PR TITLE
Using ibv_exp_reg_mr instead of ibv_reg_mr

### DIFF
--- a/benchmarks/mp_pingpong_all.cu
+++ b/benchmarks/mp_pingpong_all.cu
@@ -842,8 +842,8 @@ int main (int argc, char *argv[])
 			CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size)); 
 		}
 
-		MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-		MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+		MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+		MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
 		if (!my_rank) fprintf(stdout, "%10d", size);
 

--- a/benchmarks/mp_pingpong_kernel.cu
+++ b/benchmarks/mp_pingpong_kernel.cu
@@ -232,8 +232,8 @@ double sr_exchange (MPI_Comm comm, int size, int iter_count, int validate, doubl
     CUDA_CHECK(cudaMalloc((void **)&rbuf_d, size*iter_count));
     CUDA_CHECK(cudaMemset(rbuf_d, 0, size*iter_count)); 
  
-    MP_CHECK(mp_register(sbuf_d, size*iter_count, &sreg));
-    MP_CHECK(mp_register(rbuf_d, size*iter_count, &rreg));
+    MP_CHECK(mp_register(sbuf_d, size*iter_count, &sreg, 0));
+    MP_CHECK(mp_register(rbuf_d, size*iter_count, &rreg, 0));
 
     if (validate) {
         mp_dbg_msg("initializing the buffer \n");

--- a/benchmarks/mp_pingpong_kernel_stream.cu
+++ b/benchmarks/mp_pingpong_kernel_stream.cu
@@ -455,8 +455,8 @@ int main (int argc, char *argv[])
         CUDA_CHECK(cudaMalloc((void **)&rbuf_d, buf_size));
         CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size));
 
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
         if (!my_rank) {
             if (prof_init(&prof_normal, 1000,  1000, "1us", 100, 1, tags)) {

--- a/benchmarks/mp_pingpong_kernel_stream_latency.cu
+++ b/benchmarks/mp_pingpong_kernel_stream_latency.cu
@@ -539,8 +539,8 @@ int main (int argc, char *argv[])
         CUDA_CHECK(cudaMalloc((void **)&rbuf_d, buf_size));
         CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size)); 
  
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
         if (!my_rank) fprintf(stdout, "%10d", size);
 

--- a/benchmarks/mp_pingpong_kernel_stream_latency_mpi.cu
+++ b/benchmarks/mp_pingpong_kernel_stream_latency_mpi.cu
@@ -719,8 +719,8 @@ int main (int argc, char *argv[])
             CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size)); 
         }
 
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
         if (!my_rank) fprintf(stdout, "%10d", size);
 

--- a/benchmarks/mp_pingpong_kernel_stream_mpi.cu
+++ b/benchmarks/mp_pingpong_kernel_stream_mpi.cu
@@ -641,8 +641,8 @@ int main (int argc, char *argv[])
             CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size));
         }
 
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
         if (my_rank == 0) {
             if (prof_init(&prof_normal, 1000,  1000, "1us", 100, 1, tags)) {

--- a/benchmarks/mp_pingpong_kernel_stream_wait_send.cu
+++ b/benchmarks/mp_pingpong_kernel_stream_wait_send.cu
@@ -388,8 +388,8 @@ int main (int c, char *v[])
         CUDA_CHECK(cudaMalloc((void **)&rbuf_d, buf_size));
         CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size));
 
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
         if (!my_rank) {
             if (prof_init(&prof_normal, 1000,  1000, "1us", 100, 1, tags)) {

--- a/benchmarks/mp_producer_consumer_kernel_stream.cu
+++ b/benchmarks/mp_producer_consumer_kernel_stream.cu
@@ -373,8 +373,8 @@ int main (int c, char *v[])
         CUDA_CHECK(cudaMalloc((void **)&rbuf_d, buf_size));
         CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size)); 
  
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
 	if (!my_rank) { 
             if (prof_init(&prof_normal, 1000,  1000, "1us", 100, 1, tags)) {

--- a/benchmarks/mp_sendrecv_kernel_stream.cu
+++ b/benchmarks/mp_sendrecv_kernel_stream.cu
@@ -359,8 +359,8 @@ int main (int c, char *v[])
         CUDA_CHECK(cudaMalloc((void **)&rbuf_d, buf_size));
         CUDA_CHECK(cudaMemset(rbuf_d, 0, buf_size)); 
  
-        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+        MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+        MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
 	if (!my_rank) { 
             if (prof_init(&prof_normal, 1000,  1000, "1us", 100, 1, tags)) {

--- a/comm_library/comm.cpp
+++ b/comm_library/comm.cpp
@@ -721,12 +721,6 @@ int comm_register_odp(void *buf, size_t size, comm_reg_t *creg)
     mp_reg_t *reg = (mp_reg_t*)creg;
     assert(reg);
 
-    if (!size) {
-        ret = -EINVAL;
-        comm_err("SIZE==0\n");
-        goto out;
-    }
-
     if (!*reg) {
         DBG("registering buffer %p\n", buf);
         MP_CHECK(mp_register(buf, size, reg, IBV_EXP_ACCESS_ON_DEMAND));

--- a/comm_library/comm.cpp
+++ b/comm_library/comm.cpp
@@ -713,7 +713,7 @@ out:
     return ret;
 }
 
-int comm_register_odp(void *buf, size_t size, comm_reg_t *creg)
+int comm_register_odp(comm_reg_t *creg)
 {
     assert(comm_initialized);
     int ret = 0;
@@ -722,8 +722,8 @@ int comm_register_odp(void *buf, size_t size, comm_reg_t *creg)
     assert(reg);
 
     if (!*reg) {
-        DBG("registering buffer %p\n", buf);
-        MP_CHECK(mp_register(buf, size, reg, IBV_EXP_ACCESS_ON_DEMAND));
+        DBG("registering implicit ODP MR\n");
+        MP_CHECK(mp_register(NULL, 0, reg, IBV_EXP_ACCESS_ON_DEMAND));
     }
 
 out:

--- a/comm_library/comm.h
+++ b/comm_library/comm.h
@@ -125,7 +125,7 @@ extern "C" {
     int comm_prepare_wait_all(int count, comm_request_t *creqs);
     comm_dev_descs_t comm_prepared_requests();
     int comm_register(void *buf, size_t size, comm_reg_t *creg);
-    int comm_register_odp(void *buf, size_t size, comm_reg_t *creg);
+    int comm_register_odp(comm_reg_t *creg);
     int comm_deregister(comm_reg_t *creg);
     int comm_select_device(int mpiRank);
 

--- a/comm_library/comm.h
+++ b/comm_library/comm.h
@@ -125,6 +125,7 @@ extern "C" {
     int comm_prepare_wait_all(int count, comm_request_t *creqs);
     comm_dev_descs_t comm_prepared_requests();
     int comm_register(void *buf, size_t size, comm_reg_t *creg);
+    int comm_register_odp(void *buf, size_t size, comm_reg_t *creg);
     int comm_deregister(comm_reg_t *creg);
     int comm_select_device(int mpiRank);
 

--- a/comm_library/examples/comm_pingpong.cpp
+++ b/comm_library/examples/comm_pingpong.cpp
@@ -194,16 +194,25 @@ int main(int argc, char **argv) {
         validate = atoi(value);
     }
 
-    if(!comm_use_comm())
-        fprintf(stderr, "ERROR: pingpong + one sided for comm library only\n");
-
     MPI_Init(&argc, &argv);
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
     if (comm_size < 2 || comm_size > MAX_PEERS) { 
-    fprintf(stderr, "this test requires 2<ranks<%d\n", MAX_PEERS);
-        exit(-1);
+        fprintf(stderr, "this test requires 2<ranks<%d\n", MAX_PEERS);
+        exit(EXIT_FAILURE);
+    }
+
+    if(!comm_use_comm())
+    {
+        fprintf(stderr, "ERROR: you need to enable COMM\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if(use_odp && use_gpu_buffers)
+    {
+        fprintf(stderr, "ERROR: Can't use device memory with on-demand paging\n");
+        exit(EXIT_FAILURE);        
     }
 
     device_id = comm_select_device(my_rank);

--- a/comm_library/examples/comm_pingpong.cpp
+++ b/comm_library/examples/comm_pingpong.cpp
@@ -251,7 +251,7 @@ int main(int argc, char **argv) {
     {
         odpreg = (comm_reg_t*)calloc(1, sizeof(comm_reg_t));
         assert(odpreg);
-        COMM_CHECK(comm_register_odp(NULL, 0, &odpreg[0]));
+        COMM_CHECK(comm_register_odp(&odpreg[0]));
     }
     else
     {

--- a/comm_library/examples/comm_pingpong.cpp
+++ b/comm_library/examples/comm_pingpong.cpp
@@ -54,14 +54,24 @@ do {                                                    \
 } while (0)
 
 
-comm_reg_t * sreg, * rreg;
+comm_reg_t * sreg, * rreg, * odpreg;
 int comm_size, my_rank, device_id;
 unsigned char * send_buf[MAX_PEERS];
 unsigned char * recv_buf[MAX_PEERS];
-int use_gpu_buffers=0;
 int tot_iters=MAX_ITERS;
-int max_size=BUF_SIZE;
+int buf_size=BUF_SIZE;
+int use_gpu_buffers=0;
 int validate=0;
+int use_odp=0;
+
+static void usage()
+{
+    printf("Options:\n");
+    printf("  -g            allocate GPU intead of CPU memory buffers\n");
+    printf("  -o            use implici ODP\n");
+    printf("  -n=<iter>     number of exchanges (default %d)\n", MAX_ITERS);
+    printf("  -s=<bytes>    S/R buffer size (default %d)\n", BUF_SIZE);
+}
 
 int async_exchange(int iter) {
     int peer, n_sreqs=0, n_rreqs=0;
@@ -73,8 +83,10 @@ int async_exchange(int iter) {
     {
         if(peer != my_rank)
         {
-            comm_irecv(recv_buf[peer], max_size, MPI_CHAR, &rreg[peer], peer, &recv_requests[n_rreqs]);
-            comm_send_ready_on_stream(peer, &ready_requests[n_rreqs], NULL);
+            COMM_CHECK(comm_irecv(recv_buf[peer], buf_size, MPI_CHAR, 
+                                    (use_odp ? &odpreg[0] : &rreg[peer]),
+                                    peer, &recv_requests[n_rreqs]));
+            COMM_CHECK(comm_send_ready_on_stream(peer, &ready_requests[n_rreqs], NULL));
             n_rreqs++;
         }
     }
@@ -83,18 +95,20 @@ int async_exchange(int iter) {
     {
         if(peer != my_rank)
         {
-            comm_wait_ready_on_stream(peer,NULL);
-            comm_isend_on_stream(send_buf[peer], max_size, MPI_CHAR, 
-                            &sreg[peer], peer, &send_requests[n_sreqs], NULL);
+            COMM_CHECK(comm_wait_ready_on_stream(peer,NULL));
+            COMM_CHECK(comm_isend_on_stream(send_buf[peer], buf_size, MPI_CHAR,
+                            (use_odp ? &odpreg[0] : &sreg[peer]),
+                            peer, &send_requests[n_sreqs], NULL));
 
             n_sreqs++;
         }
     }
 
-    comm_wait_all_on_stream(n_rreqs, recv_requests, NULL);
-    comm_wait_all_on_stream(n_sreqs, send_requests, NULL);
-    //comm_wait_all_on_stream(n_rreqs, ready_requests, NULL);
+    COMM_CHECK(comm_wait_all_on_stream(n_rreqs, recv_requests, NULL));
+    COMM_CHECK(comm_wait_all_on_stream(n_rreqs, ready_requests, NULL));
+    COMM_CHECK(comm_wait_all_on_stream(n_sreqs, send_requests, NULL));
 
+    //printf("Before progress, %d iter, %d n_rreqs, %d n_sreqs, %d comm_size\n", iter, n_rreqs, n_sreqs, comm_size);
     comm_progress();
 }
 
@@ -108,8 +122,10 @@ int sync_exchange(int iter) {
     {
         if(peer != my_rank)
         {
-            comm_irecv(recv_buf[peer], max_size, MPI_CHAR, &rreg[peer], peer, &recv_requests[n_rreqs]);
-            comm_send_ready(peer, &ready_requests[n_rreqs]);
+            COMM_CHECK(comm_irecv(recv_buf[peer], buf_size, MPI_CHAR, 
+                                    (use_odp ? &odpreg[0] : &rreg[peer]),
+                                    peer, &recv_requests[n_rreqs]));
+            COMM_CHECK(comm_send_ready(peer, &ready_requests[n_rreqs]));
             n_rreqs++;
         }
     }
@@ -118,13 +134,15 @@ int sync_exchange(int iter) {
     {
         if(peer != my_rank)
         {
-            comm_wait_ready(peer);
-            comm_isend(send_buf[peer], max_size, MPI_CHAR, 
-                            &sreg[peer], peer, &send_requests[n_sreqs]);
+            COMM_CHECK(comm_wait_ready(peer));
+            COMM_CHECK(comm_isend(send_buf[peer], buf_size, MPI_CHAR, 
+                            (use_odp ? &odpreg[0] : &sreg[peer]),
+                            peer, &send_requests[n_sreqs]));
 
             n_sreqs++;
         }
     }
+
     comm_flush();
 }
 
@@ -132,28 +150,45 @@ int main(int argc, char **argv) {
     int i,j,k,iter;
     char *value;
     double tot_time, start_time, stop_time;
+    int c;
 
-    value = getenv("USE_GPU_BUFFERS");
-    if (value != NULL) {
-        use_gpu_buffers = atoi(value);
-    }
+        while (1) {
 
-    value = getenv("MAX_SIZE");
-    if (value != NULL) {
-        max_size = atoi(value);
-    }
+        c = getopt(argc, argv, "gon:s:");
+        if (c == -1)
+            break;
 
-    value = getenv("TOT_ITERS");
-    if (value != NULL) {
-        tot_iters = atoi(value);
-        if(tot_iters > MAX_ITERS)
-        {
-            printf("ERROR: max iters number allowed=%d\n", MAX_ITERS);
-            tot_iters = MAX_ITERS;
+        switch (c) {
+        case 'g':
+            use_gpu_buffers=1;
+            printf("Using GPU memory for communication buffers\n");
+            break;
+
+        case 'n':
+            tot_iters = strtol(optarg, NULL, 0);
+            if(tot_iters > MAX_ITERS)
+                tot_iters = MAX_ITERS;
+            printf("Tot iters=%d\n", tot_iters);
+            break;
+
+        case 'o':
+            use_odp=1;
+            printf("Using implicit ODP\n");
+            break;
+
+
+        case 's':
+            buf_size=strtol(optarg, NULL, 0);
+            printf("Using buf_size=%d\n", buf_size);
+            
+            break;
+
+        default:
+            usage();
+            return 1;
         }
-
     }
-    
+   
     value = getenv("ENABLE_VALIDATION");
     if (value != NULL) {
         validate = atoi(value);
@@ -166,48 +201,60 @@ int main(int argc, char **argv) {
     MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
 
-    assert(comm_size <= MAX_PEERS);
+    if (comm_size < 2 || comm_size > MAX_PEERS) { 
+    fprintf(stderr, "this test requires 2<ranks<%d\n", MAX_PEERS);
+        exit(-1);
+    }
 
     device_id = comm_select_device(my_rank);
-    cudaSetDevice(device_id);
+    CUDA_CHECK(cudaSetDevice(device_id));
     if (my_rank < 10) {
         struct cudaDeviceProp devProp;
-        cudaGetDeviceProperties(&devProp, device_id);
+        CUDA_CHECK(cudaGetDeviceProperties(&devProp, device_id));
         printf("rank %d:  Selecting device %d (%s)\n",my_rank,device_id,devProp.name);
     }
     
     comm_init(MPI_COMM_WORLD, device_id);
-
     
     for(i=0; i<comm_size; i++)
     {
         if(!use_gpu_buffers)
         {
-            CUDA_CHECK(cudaMallocHost((void **)&send_buf[i], max_size*sizeof(char)));
+            CUDA_CHECK(cudaMallocHost((void **)&send_buf[i], buf_size*sizeof(char)));
             assert(send_buf[i]);
-            memset(send_buf[i], 9, max_size*sizeof(char));
+            memset(send_buf[i], 9, buf_size*sizeof(char));
 
-            CUDA_CHECK(cudaMallocHost((void **)&recv_buf[i], max_size*sizeof(char)));
+            CUDA_CHECK(cudaMallocHost((void **)&recv_buf[i], buf_size*sizeof(char)));
             assert(recv_buf[i]);
-            memset(recv_buf[i], 0, max_size*sizeof(char));            
+            memset(recv_buf[i], 0, buf_size*sizeof(char));            
         }
         else
         {
-            CUDA_CHECK(cudaMalloc((void **)&send_buf[i], max_size*sizeof(char)));
-            CUDA_CHECK(cudaMemset(send_buf[i], 9, max_size*sizeof(char)));
+            CUDA_CHECK(cudaMalloc((void **)&send_buf[i], buf_size*sizeof(char)));
+            CUDA_CHECK(cudaMemset(send_buf[i], 9, buf_size*sizeof(char)));
 
-            CUDA_CHECK(cudaMalloc((void **)&recv_buf[i], max_size*sizeof(char)));
-            CUDA_CHECK(cudaMemset(recv_buf[i], 0, max_size*sizeof(char)));
+            CUDA_CHECK(cudaMalloc((void **)&recv_buf[i], buf_size*sizeof(char)));
+            CUDA_CHECK(cudaMemset(recv_buf[i], 0, buf_size*sizeof(char)));
         }
     }
 
-    //1 region for each buffer
-    sreg = (comm_reg_t*)calloc(comm_size, sizeof(comm_reg_t));
-    rreg = (comm_reg_t*)calloc(comm_size, sizeof(comm_reg_t));
-    
+    if(use_odp)
+    {
+        odpreg = (comm_reg_t*)calloc(1, sizeof(comm_reg_t));
+        assert(odpreg);
+        COMM_CHECK(comm_register_odp(NULL, 0, &odpreg[0]));
+    }
+    else
+    {
+        sreg = (comm_reg_t*)calloc(comm_size, sizeof(comm_reg_t));
+        assert(sreg);
+        rreg = (comm_reg_t*)calloc(comm_size, sizeof(comm_reg_t));
+        assert(sreg);        
+    }
+
     if(!my_rank) 
-        printf("----> async sa=%d, use_gpu_buffers=%d, max_size=%d, tot_iters=%d num peers=%d validate=%d\n", 
-                    comm_use_model_sa()?1:0, use_gpu_buffers, max_size, tot_iters, comm_size, validate);
+        printf("# SA Model=%d\n# use_gpu_buffers=%d\n# buf_size=%d\n# tot_iters=%d\n# num peers=%d\n# validate=%d\n# use_odp=%d\n",
+                    comm_use_model_sa()?1:0, use_gpu_buffers, buf_size, tot_iters, comm_size, validate, use_odp);
 
     start_time = MPI_Wtime();
     for(iter=0; iter<tot_iters; iter++)
@@ -220,8 +267,8 @@ int main(int argc, char **argv) {
 
     if(comm_use_model_sa())
     {
-        cudaDeviceSynchronize();
-        comm_flush();
+        CUDA_CHECK(cudaDeviceSynchronize());
+        COMM_CHECK(comm_flush());
     }   
     stop_time = MPI_Wtime();
 
@@ -247,8 +294,13 @@ int main(int argc, char **argv) {
         } 
     }
 
-    free(sreg);
-    free(rreg);
+    if(use_odp)
+        free(odpreg);
+    else
+    {
+        free(sreg);
+        free(rreg);
+    }
 
     comm_finalize();
     MPI_Finalize();

--- a/examples/mp_putget.c
+++ b/examples/mp_putget.c
@@ -81,7 +81,7 @@ int put_exchange (MPI_Comm comm, int size, int iter_count, int window_size, int 
 		memset(buf_d, 0, buf_size);
 	}
 
-	MP_CHECK(mp_register(buf_d, buf_size, &reg));
+	MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
 
 	MP_CHECK(mp_window_create(buf_d, buf_size, &win));
 
@@ -189,8 +189,8 @@ int put_exchange_on_stream (MPI_Comm comm, int size, int iter_count, int window_
 		memset(buf_d, 0, buf_size);
 	}
 
-	MP_CHECK(mp_register(buf_d, buf_size, &reg));
-	MP_CHECK(mp_register(signal, 4096, &signal_reg));
+	MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
+	MP_CHECK(mp_register(signal, 4096, &signal_reg, 0));
 
 	MP_CHECK(mp_window_create(buf_d, buf_size, &win));
 
@@ -329,8 +329,8 @@ int put_desc_exchange_on_stream (MPI_Comm comm, int size, int iter_count, int wi
 	mp_desc_queue_t dq = NULL;
 	MP_CHECK(mp_desc_queue_alloc(&dq));
 
-	MP_CHECK(mp_register(buf_d, buf_size, &reg));
-	MP_CHECK(mp_register(signal, 4096, &signal_reg));
+	MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
+	MP_CHECK(mp_register(signal, 4096, &signal_reg, 0));
 
 	MP_CHECK(mp_window_create(buf_d, buf_size, &win));
 
@@ -478,8 +478,8 @@ int put_desc_nowait_exchange_on_stream (MPI_Comm comm, int size, int iter_count,
 	mp_desc_queue_t dq = NULL;
 	MP_CHECK(mp_desc_queue_alloc(&dq));
 
-	MP_CHECK(mp_register(buf_d, buf_size, &reg));
-	MP_CHECK(mp_register(signal, 4096, &signal_reg));
+	MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
+	MP_CHECK(mp_register(signal, 4096, &signal_reg, 0));
 
 	MP_CHECK(mp_window_create(buf_d, buf_size, &win));
 
@@ -616,7 +616,7 @@ int get_exchange (MPI_Comm comm, int size, int iter_count, int window_size, int 
 		memset(buf_d, 0, buf_size);
 	}
 
-	MP_CHECK(mp_register(buf_d, buf_size, &reg));
+	MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
 
 	MP_CHECK(mp_window_create(buf_d, buf_size, &win));
 

--- a/examples/mp_sendrecv.c
+++ b/examples/mp_sendrecv.c
@@ -65,7 +65,7 @@ int sr_exchange (MPI_Comm comm, int size, int iter_count, int window_size, int v
     CUDA_CHECK(cudaMalloc((void **)&buf_d, buf_size));
     CUDA_CHECK(cudaMemset(buf_d, 0, buf_size)); 
 
-    MP_CHECK(mp_register(buf_d, buf_size, &reg));
+    MP_CHECK(mp_register(buf_d, buf_size, &reg, 0));
 
     dbg_msg("registered ptr: %p size: %zu\n", buf_d, buf_size);
 

--- a/examples/mp_sendrecv_kernel.cu
+++ b/examples/mp_sendrecv_kernel.cu
@@ -127,8 +127,8 @@ int sr_exchange (MPI_Comm comm, int size, int iter_count, int validate)
  
     CUDA_CHECK(cudaStreamCreate(&stream));	
 
-    MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-    MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+    MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+    MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
     if (validate) {
         CUDA_CHECK(cudaMemset(sbuf_d, (my_rank + 1), buf_size));

--- a/examples/mp_sendrecv_stream.c
+++ b/examples/mp_sendrecv_stream.c
@@ -75,8 +75,8 @@ int sr_exchange (MPI_Comm comm, int size, int iter_count, int validate)
  
     CUDA_CHECK(cudaStreamCreate(&stream));	
 
-    MP_CHECK(mp_register(sbuf_d, buf_size, &sreg));
-    MP_CHECK(mp_register(rbuf_d, buf_size, &rreg));
+    MP_CHECK(mp_register(sbuf_d, buf_size, &sreg, 0));
+    MP_CHECK(mp_register(rbuf_d, buf_size, &rreg, 0));
 
     if (validate) {
         CUDA_CHECK(cudaMemset(sbuf_d, (my_rank + 1), buf_size));

--- a/include/mp.h
+++ b/include/mp.h
@@ -85,7 +85,7 @@ enum mp_init_flags {
 int mp_init(MPI_Comm comm, int *peers, int count, int flags, int gpu_id);
 void mp_finalize();
 
-int mp_register(void *addr, size_t length, mp_reg_t *reg_t, int exp_flags);
+int mp_register(void *addr, size_t length, mp_reg_t *reg_t, uint64_t exp_flags);
 int mp_deregister(mp_reg_t *reg);
 
 /*

--- a/include/mp.h
+++ b/include/mp.h
@@ -85,7 +85,7 @@ enum mp_init_flags {
 int mp_init(MPI_Comm comm, int *peers, int count, int flags, int gpu_id);
 void mp_finalize();
 
-int mp_register(void *addr, size_t length, mp_reg_t *reg_t);
+int mp_register(void *addr, size_t length, mp_reg_t *reg_t, int exp_flags);
 int mp_deregister(mp_reg_t *reg);
 
 /*

--- a/src/mp.c
+++ b/src/mp.c
@@ -762,7 +762,7 @@ int mp_register(void *addr, size_t length, mp_reg_t *reg_, uint64_t exp_flags)
                  IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC;
     }  
 
-    mp_dbg_msg(stderr, "exp_flags=%llx\n", exp_flags);
+    mp_dbg_msg("exp_flags=%llx\n", exp_flags);
 
     if(exp_flags & IBV_EXP_ACCESS_ON_DEMAND)
     {


### PR DESCRIPTION
Libmp:
- mp_register() now uses ibv_exp_reg_mr instead of ibv_reg_mr in order to take the advantage of the new IBV_EXP flags
- mp_register() now enables implicit ODP in case of (exp_flag & IBV_EXP_ACCESS_ON_DEMAND)

Comm:
- new function comm_register_odp() useful to call mp_register with IBV_EXP_ACCESS_ON_DEMAND
- comm_pingpong test reworked with input options instead of env vars